### PR TITLE
Don't ignore the case where the updated active prop is 0

### DIFF
--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -85,7 +85,7 @@ class Coverflow extends Component {
       height: ReactDOM.findDOMNode(this).offsetHeight
     };
     var baseWidth = state.width / (displayQuantityOfSide * 2 + 1);
-    var active = active || this.props.active;
+    var active = (typeof active === 'number') ? active : this.props.active;
     if (typeof active === 'number' && ~~active < length) {
       active = ~~active;
       var move = 0;


### PR DESCRIPTION
The existing check at line 88 would always fail if the new value of `active` was zero, and would thus use the existing value of `this.props.active`.
The new code doesn't use `||` to detect a bad argument, rather using `typeof`.